### PR TITLE
style(Stats): optimize mobile layout for better readability

### DIFF
--- a/src/features/expense/pages/Stats.jsx
+++ b/src/features/expense/pages/Stats.jsx
@@ -62,10 +62,10 @@ function Stats() {
         textAnchor={textAnchor}
         dominantBaseline="central"
       >
-        <tspan x={x} dy="-0.6em" fontWeight="600" fontSize="16px">
+        <tspan x={x} dy="-0.6em" fontWeight="600" fontSize="15px">
           {name}
         </tspan>
-        <tspan x={x} dy="1.4em" fontSize="14px">
+        <tspan x={x} dy="1.4em" fontSize="13px">
           ${value}
         </tspan>
       </text>
@@ -83,18 +83,21 @@ function Stats() {
   return (
     <section>
       <div className={styles.statsControls}>
+        <span className={styles.yearDisplay}>
+          {isMobile ? currentDate.format("YYYY") : ""}
+        </span>
         <div className={styles.viewToggle}>
           <Button
             onClick={() => setViewType("monthly")}
             className={viewType === "monthly" ? styles.active : ""}
           >
-            Monthly
+            {isMobile ? "Mo." : "Monthly"}
           </Button>
           <Button
             onClick={() => setViewType("yearly")}
             className={viewType === "yearly" ? styles.active : ""}
           >
-            Yearly
+            {isMobile ? "Yr." : "Yearly"}
           </Button>
         </div>
         <div className={styles.dateNav}>
@@ -103,7 +106,7 @@ function Stats() {
           </Button>
           <span className={styles.dateDisplay}>
             {viewType === "monthly"
-              ? currentDate.format("YYYY MMMM")
+              ? currentDate.format("MMMM")
               : currentDate.format("YYYY")}
           </span>
           <Button onClick={handleNext} disabled={isFuture}>
@@ -174,8 +177,13 @@ function Stats() {
                   dataKey="date"
                   tickLine={false}
                   tickFormatter={formatXAxis}
-                  tick={{ fontSize: "inherit" }}
+                  tick={{
+                    fontSize: isMobile ? 14 : 18,
+                    textAnchor: isMobile ? "end" : "middle",
+                    dy: -1,
+                  }}
                   interval={viewType === "monthly" ? 3 : 0}
+                  angle={isMobile ? -45 : 0}
                 />
                 <YAxis width="auto" tickLine={false} />
                 <Tooltip

--- a/src/features/expense/pages/Stats.module.css
+++ b/src/features/expense/pages/Stats.module.css
@@ -1,16 +1,11 @@
 .statsControls {
+  position: relative;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin: 2rem 0;
+  margin: 1.5rem 0 1rem 0;
   gap: 1rem;
   font-size: 1.2rem;
-}
-
-@media (max-width: 768px) {
-  .statsControls {
-    flex-direction: column;
-  }
 }
 
 .statsControls button {
@@ -38,6 +33,23 @@
   font-weight: 600;
   min-width: 150px;
   text-align: center;
+}
+
+@media (max-width: 768px) {
+  .statsControls {
+    font-size: 14px;
+  }
+
+  .dateDisplay {
+    min-width: 75px;
+  }
+}
+
+.yearDisplay {
+  position: absolute;
+  left: 2px;
+  top: -30px;
+  font-weight: 600;
 }
 
 .emptyState {
@@ -71,6 +83,16 @@
 
 .barContainer {
   flex: 2 1 500px;
+}
+
+.responsiveTick {
+  font-size: 12px !important;
+}
+
+@media (max-width: 850px) {
+  .responsiveTick {
+    font-size: 9px !important;
+  }
 }
 
 :global(.recharts-default-legend) {


### PR DESCRIPTION
Refined the layout of the Stats Page for better mobile readability.

**Key changes**:
- Control Area: Reorganized navigation buttons and date display for better spacing on narrow screens
- Chart Visuals: Adjusted PieChart labels and BarChart intervals to prevent overlapping on mobile viewports

**Related Issues**:
closes #16 