### PR TITLE
refactor(AddExpense): remove hardcoded user_id

### DIFF
--- a/src/features/expense/pages/AddExpense.jsx
+++ b/src/features/expense/pages/AddExpense.jsx
@@ -8,12 +8,7 @@ function AddExpense() {
     <section className={styles.addExpenseContainer}>
       <h2>Add New Expense 💲</h2>
       <ExpenseForm
-        onSubmit={(data) =>
-          addExpense({
-            ...data,
-            user_id: "36a8bcb9-efd6-4be0-880c-d80f95068c3b",
-          })
-        }
+        onSubmit={(data) => addExpense({ data })}
         isSubmitting={isAdding}
         submitLabel="Add"
       />


### PR DESCRIPTION
Removed the hardcoded `user_id` in the `AddExpense` which was previously used for development convenience. Form submission now relies on dynamic data.

**Key Changes**
- Removed static `user_id` string from AddExpense.jsx.
- Simplified the `onSubmit` data handling logic.