### PR TITLE
Fix: Automatically include user_id in ExpenseForm submissions

### DIFF
--- a/src/features/expense/components/ExpenseForm.jsx
+++ b/src/features/expense/components/ExpenseForm.jsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { format } from "date-fns";
 import { useRecentExpenses } from "../hooks/useExpenses";
+import { useUser } from "../../user/useUser";
 
 import FormRow from "../../ui/FormRow";
 import Button from "../../ui/Button";
@@ -20,6 +21,7 @@ function ExpenseForm({
   submitLabel = "Save",
   onCancel,
 }) {
+  const { user } = useUser();
   const today = format(new Date(), "yyyy-MM-dd");
 
   const [type, setType] = useState(defaultValues.type || "expense");
@@ -109,6 +111,7 @@ function ExpenseForm({
       type: type,
       amount: Number(data.amount),
       image: imageValue,
+      user_id: user?.id,
     });
 
     if (submitLabel === "Add") {

--- a/src/features/expense/pages/AddExpense.jsx
+++ b/src/features/expense/pages/AddExpense.jsx
@@ -8,7 +8,7 @@ function AddExpense() {
     <section className={styles.addExpenseContainer}>
       <h2>Add New Expense 💲</h2>
       <ExpenseForm
-        onSubmit={(data) => addExpense({ data })}
+        onSubmit={(data) => addExpense(data)}
         isSubmitting={isAdding}
         submitLabel="Add"
       />

--- a/src/hooks/useDashboardStats.js
+++ b/src/hooks/useDashboardStats.js
@@ -57,7 +57,6 @@ export function useDashboardStats(allExpenses) {
 
             if (isSameDay(expenseDate, now)) {
               acc[target].today += amount;
-              console.log("找到今天的資料了！", expense);
             }
           }
         }

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -14,7 +14,6 @@ import SummaryRow from "../features/ui/SummaryRow";
 
 function Dashboard() {
   const { data: allExpenses = [], isLoading } = useAllExpenses();
-  console.log(allExpenses.length);
   const { metrics, summaryData } = useDashboardStats(allExpenses);
 
   if (isLoading) {


### PR DESCRIPTION
**Description**:
Ensure `user_id` is added when submitting or editing expenses via `ExpenseForm` to comply with Supabase RLS policies.
Prevents insert failures caused by missing `user_id` in transaction payloads.

**Related Issue**:
Closes #25 