### PR TITLE
Fix transaction ordering by adding created_at as secondary sort

### DIFF
--- a/src/services/apiTransactions.js
+++ b/src/services/apiTransactions.js
@@ -4,7 +4,8 @@ export async function getAllExpenses() {
   const { data, error } = await supabase
     .from("transactions")
     .select("*")
-    .order("transaction_date", { ascending: false });
+    .order("transaction_date", { ascending: false })
+    .order("created_at", { ascending: false });
 
   if (error) {
     console.error(error);
@@ -20,6 +21,7 @@ export async function getRecentExpenses() {
     .from("transactions")
     .select("*")
     .order("transaction_date", { ascending: false })
+    .order("created_at", { ascending: false })
     .limit(50);
 
   if (error) {


### PR DESCRIPTION
## What
This PR intentionally limits changes to the ordering logic only.
Add `created_at` as a secondary sort key after `transaction_date` to ensure consistent ordering when multiple records share the same transaction date.

## Why
Sorting only by `transaction_date` can lead to unstable ordering when there are ties, causing items to appear in different positions across refreshes/pages.

## Changes
- Keep sorting by `transaction_date` (desc)
- Add secondary sorting by `created_at` (desc)

## Testing
- [ ] Verified the ordering is consistent when multiple items have the same `transaction_date`
- [ ] Confirmed no other query logic is changed