### PR TITLE
Add AI receipt scanning (Azure OpenAI vision → autofill)

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -11,7 +11,8 @@
         "@azure/functions": "^4.0.0",
         "@azure/storage-blob": "^12.33.0",
         "@supabase/supabase-js": "^2.111.0",
-        "date-fns": "^4.4.0"
+        "date-fns": "^4.4.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -590,6 +591,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/api/package.json
+++ b/api/package.json
@@ -15,10 +15,11 @@
     "@azure/functions": "^4.0.0",
     "@azure/storage-blob": "^12.33.0",
     "@supabase/supabase-js": "^2.111.0",
-    "date-fns": "^4.4.0"
+    "date-fns": "^4.4.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
-    "typescript": "^5.6.0",
-    "@types/node": "^22.0.0"
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0"
   }
 }

--- a/api/src/functions/receipt.ts
+++ b/api/src/functions/receipt.ts
@@ -1,0 +1,107 @@
+import {
+  app,
+  HttpRequest,
+  HttpResponseInit,
+  InvocationContext,
+} from "@azure/functions";
+import { chatCompletionJson } from "../lib/openai.js";
+import { receiptSchema, type Receipt } from "../schemas/receipt.js";
+
+const SYSTEM_PROMPT = `You are a receipt parsing assistant for a personal finance app.
+Extract structured data from the receipt image. Respond with ONLY a JSON object.
+Schema:
+{
+  "merchant": string | null,          // store / vendor name
+  "total_amount": number | null,      // final total paid, number only (no currency symbol)
+  "currency": string | null,          // ISO code if visible, else best guess e.g. "USD", "TWD"
+  "date": string | null,              // transaction date as YYYY-MM-DD, or null if not visible
+  "suggested_category": string        // one of: Food, Transport, Housing, Entertainment, Health, Other
+}
+Use null for any unreadable field.`;
+
+// "malformed_json": the model returned non-JSON (a model/prompt problem)
+// "empty": valid JSON, but nothing meaningful was read (an image problem)
+type ExtractOutcome =
+  | { ok: true; receipt: Receipt }
+  | { ok: false; reason: "malformed_json" | "empty" };
+
+async function extractReceipt(image: string): Promise<ExtractOutcome> {
+  const content = await chatCompletionJson([
+    { role: "system", content: SYSTEM_PROMPT },
+    {
+      role: "user",
+      content: [
+        { type: "text", text: "Extract the receipt fields as JSON." },
+        { type: "image_url", image_url: { url: image } },
+      ],
+    },
+  ]);
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(content);
+  } catch {
+    return { ok: false, reason: "malformed_json" };
+  }
+
+  const parsed = receiptSchema.parse(raw);
+
+  if (parsed.merchant === null && parsed.total_amount === null) {
+    return { ok: false, reason: "empty" };
+  }
+  return { ok: true, receipt: parsed };
+}
+
+app.http("receipt-parse", {
+  methods: ["POST"],
+  authLevel: "anonymous", // TODO: add JWT auth
+  route: "receipt/parse",
+  handler: async (
+    request: HttpRequest,
+    context: InvocationContext,
+  ): Promise<HttpResponseInit> => {
+    try {
+      const body = (await request.json()) as { image?: string };
+      if (!body.image) {
+        return {
+          status: 400,
+          jsonBody: { error: "Missing 'image' (base64 data URL)" },
+        };
+      }
+
+      // Retry once before giving up
+      let outcome = await extractReceipt(body.image);
+      if (!outcome.ok) {
+        context.log(
+          `receipt-parse: attempt 1 failed (${outcome.reason}), retrying`,
+        );
+        outcome = await extractReceipt(body.image);
+      }
+
+      if (outcome.ok) {
+        return { jsonBody: outcome.receipt };
+      }
+
+      // Final failure
+      context.log(`receipt-parse: gave up (${outcome.reason})`);
+      if (outcome.reason === "empty") {
+        return {
+          status: 422,
+          jsonBody: {
+            error: "Unable to read receipt. Please upload a clearer image.",
+          },
+        };
+      }
+      return {
+        status: 502,
+        jsonBody: {
+          error: "Couldn't read the receipt reliably. Please try again.",
+        },
+      };
+    } catch (err) {
+      // Genuine backend/API failure
+      context.log("receipt-parse error:", err);
+      return { status: 500, jsonBody: { error: "Failed to parse receipt" } };
+    }
+  },
+});

--- a/api/src/functions/receipt.ts
+++ b/api/src/functions/receipt.ts
@@ -5,6 +5,7 @@ import {
   InvocationContext,
 } from "@azure/functions";
 import { chatCompletionJson } from "../lib/openai.js";
+import { getUserId } from "../lib/auth.js";
 import { receiptSchema, type Receipt } from "../schemas/receipt.js";
 
 const SYSTEM_PROMPT = `You are a receipt parsing assistant for a personal finance app.
@@ -54,13 +55,18 @@ async function extractReceipt(image: string): Promise<ExtractOutcome> {
 
 app.http("receipt-parse", {
   methods: ["POST"],
-  authLevel: "anonymous", // TODO: add JWT auth
+  authLevel: "anonymous", // Azure key off; gate with a Supabase JWT in-handler
   route: "receipt/parse",
   handler: async (
     request: HttpRequest,
     context: InvocationContext,
   ): Promise<HttpResponseInit> => {
     try {
+      const userId = await getUserId(request);
+      if (!userId) {
+        return { status: 401, jsonBody: { error: "Unauthorized" } };
+      }
+
       const body = (await request.json()) as { image?: string };
       if (!body.image) {
         return {

--- a/api/src/lib/auth.ts
+++ b/api/src/lib/auth.ts
@@ -1,0 +1,17 @@
+import { createClient } from "@supabase/supabase-js";
+import type { HttpRequest } from "@azure/functions";
+
+const supabase = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_KEY!,
+);
+
+export async function getUserId(request: HttpRequest): Promise<string | null> {
+  const authHeader = request.headers.get("authorization") ?? "";
+  const token = authHeader.replace(/^Bearer\s+/i, "").trim();
+  if (!token) return null;
+
+  const { data, error } = await supabase.auth.getUser(token);
+  if (error || !data.user) return null;
+  return data.user.id;
+}

--- a/api/src/lib/openai.ts
+++ b/api/src/lib/openai.ts
@@ -1,0 +1,39 @@
+// Thin wrapper around the Azure OpenAI API
+
+const endpoint = process.env.AZURE_OPENAI_ENDPOINT!.replace(/\/$/, "");
+const key = process.env.AZURE_OPENAI_KEY!;
+const deployment = process.env.AZURE_OPENAI_DEPLOYMENT!;
+const apiVersion = process.env.AZURE_OPENAI_API_VERSION!;
+
+export type ChatMessage = {
+  role: "system" | "user" | "assistant";
+  content: unknown; // string or an array of content parts (text + image)
+};
+
+export async function chatCompletionJson(
+  messages: ChatMessage[],
+): Promise<string> {
+  const url = `${endpoint}/openai/deployments/${deployment}/chat/completions?api-version=${apiVersion}`;
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "api-key": key,
+    },
+    body: JSON.stringify({
+      messages,
+      response_format: { type: "json_object" },
+    }),
+  });
+
+  if (!res.ok) {
+    const errText = await res.text();
+    throw new Error(`Azure OpenAI ${res.status}: ${errText}`);
+  }
+
+  const data = (await res.json()) as {
+    choices: { message: { content: string } }[];
+  };
+  return data.choices[0].message.content;
+}

--- a/api/src/lib/openai.ts
+++ b/api/src/lib/openai.ts
@@ -24,6 +24,7 @@ export async function chatCompletionJson(
     body: JSON.stringify({
       messages,
       response_format: { type: "json_object" },
+      reasoning_effort: "low", // Cuts tokens/latency
     }),
   });
 

--- a/api/src/schemas/receipt.ts
+++ b/api/src/schemas/receipt.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+export const CATEGORIES = [
+  "Food",
+  "Transport",
+  "Housing",
+  "Entertainment",
+  "Health",
+  "Other",
+] as const;
+
+export const receiptSchema = z.object({
+  merchant: z.string().nullable().catch(null),
+  total_amount: z.coerce.number().nullable().catch(null),
+  currency: z.string().nullable().catch(null),
+  date: z.string().nullable().catch(null),
+  suggested_category: z.enum(CATEGORIES).catch("Other"),
+});
+
+export type Receipt = z.infer<typeof receiptSchema>;

--- a/src/features/expense/components/ExpenseForm.jsx
+++ b/src/features/expense/components/ExpenseForm.jsx
@@ -3,7 +3,9 @@ import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { format } from "date-fns";
 import { useRecentExpenses } from "../hooks/useExpenses";
+import { useParseReceipt } from "../hooks/useParseReceipt";
 import { useUser } from "../../user/useUser";
+import toast from "react-hot-toast";
 
 import FormRow from "../../ui/FormRow";
 import Button from "../../ui/Button";
@@ -53,6 +55,39 @@ function ExpenseForm({
   const currentImage = watch("image");
   const hasImage =
     currentImage instanceof FileList ? currentImage.length > 0 : !!currentImage;
+
+  // Only a freshly-selected file can be scanned
+  const selectedFile =
+    currentImage instanceof FileList
+      ? currentImage[0]
+      : currentImage instanceof File
+        ? currentImage
+        : null;
+
+  const { scanReceipt, isScanning } = useParseReceipt();
+
+  const handleScan = () => {
+    if (!selectedFile) return;
+    scanReceipt(selectedFile, {
+      onSuccess: (data) => {
+        setType("expense");
+        if (data.merchant)
+          setValue("item", data.merchant, { shouldValidate: true });
+        if (data.total_amount != null)
+          setValue("amount", data.total_amount, { shouldValidate: true });
+        if (data.date)
+          setValue("transaction_date", data.date, { shouldValidate: true });
+        if (
+          data.suggested_category &&
+          CATEGORIES.expense.includes(data.suggested_category)
+        )
+          setValue("category", data.suggested_category, {
+            shouldValidate: true,
+          });
+        toast.success("Receipt scanned — please review the fields");
+      },
+    });
+  };
 
   const handleRemoveImage = () => {
     setValue("image", null);
@@ -224,6 +259,15 @@ function ExpenseForm({
                     ? "Existing Image"
                     : "New Image Selected"}
                 </span>
+                {selectedFile && (
+                  <Button
+                    type="button"
+                    onClick={handleScan}
+                    disabled={isScanning}
+                  >
+                    {isScanning ? "Scanning…" : "✨ Scan receipt"}
+                  </Button>
+                )}
                 <Button
                   onClick={handleRemoveImage}
                   className={styles.deleteBtn}

--- a/src/features/expense/hooks/useParseReceipt.js
+++ b/src/features/expense/hooks/useParseReceipt.js
@@ -1,0 +1,46 @@
+import { useMutation } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+import supabase from "../../../services/supabase";
+
+// Turn a File into a base64 data URL
+function fileToDataUrl(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(new Error("Could not read the image file"));
+    reader.readAsDataURL(file);
+  });
+}
+
+async function parseReceipt(file) {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session) throw new Error("You must be logged in to scan a receipt");
+
+  const image = await fileToDataUrl(file);
+
+  const res = await fetch("/api/receipt/parse", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.access_token}`,
+    },
+    body: JSON.stringify({ image }),
+  });
+
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(body.error || "Could not scan receipt");
+  }
+  return body;
+}
+
+export function useParseReceipt() {
+  const { mutate, isPending } = useMutation({
+    mutationFn: parseReceipt,
+    onError: (err) => toast.error(err.message),
+  });
+
+  return { scanReceipt: mutate, isScanning: isPending };
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,13 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  server: {
+    // forward /api/* to the Azure Functions host
+    proxy: {
+      "/api": "http://localhost:7071",
+    },
+  },
+});


### PR DESCRIPTION
Adds an AI receipt scanner: upload a receipt photo and the expense form is auto-filled from a vision model.

- POST /api/receipt/parse: Azure OpenAI gpt-5-mini vision → Zod-validated JSON 
- Defensive handling: retry once, distinct 422 (unreadable) / 502 (bad model output) / 500 (backend) responses
- Supabase JWT auth gates the endpoint before any AI call
- reasoning_effort=low to cut tokens/latency