### PR TITLE
Fix receipt auth on Azure SWA (custom token header)

### DIFF
--- a/api/src/lib/auth.ts
+++ b/api/src/lib/auth.ts
@@ -7,8 +7,13 @@ const supabase = createClient(
 );
 
 export async function getUserId(request: HttpRequest): Promise<string | null> {
-  const authHeader = request.headers.get("authorization") ?? "";
-  const token = authHeader.replace(/^Bearer\s+/i, "").trim();
+  // Azure SWA consumes Authorization header before it reaches
+  // managed functions, so the client sends the token in a custom header
+  const token =
+    request.headers.get("x-supabase-token")?.trim() ||
+    (request.headers.get("authorization") ?? "")
+      .replace(/^Bearer\s+/i, "")
+      .trim();
   if (!token) return null;
 
   const { data, error } = await supabase.auth.getUser(token);

--- a/src/features/expense/hooks/useParseReceipt.js
+++ b/src/features/expense/hooks/useParseReceipt.js
@@ -24,7 +24,8 @@ async function parseReceipt(file) {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${session.access_token}`,
+      // Custom header: SWA strips Authorization before it reaches the function
+      "x-supabase-token": session.access_token,
     },
     body: JSON.stringify({ image }),
   });


### PR DESCRIPTION
Azure Static Web Apps strips the Authorization header before it reaches managed functions, causing 401s on /api/receipt/parse in production (works locally). Switch to a custom `x-supabase-token` header; backend falls back to Authorization for local dev.